### PR TITLE
hotfix-mb.coordinatesutility.view.originCooridnates.title

### DIFF
--- a/Resources/views/Element/coordinatesutility.html.twig
+++ b/Resources/views/Element/coordinatesutility.html.twig
@@ -17,9 +17,9 @@
     </div>
 
     <div class="block coordinates-intern">
-        <p>{{ "mb.maptool.clickcoordinate.intern.coords.title" | trans }}</p>
+        <p>{{ "mb.coordinatesutility.view.originCoordinates.title" | trans }}</p>
         <div class="input-to-clipboard">
-            <input class="input map-coordinate" type="text" title="{{ "mb.coordinatesutility.view.originCooridnates.title" | trans }} ({{ "mb.coordinatesutility.view.originCooridnates.tooltip" | trans }})" readonly="true" value=""/>
+            <input class="input map-coordinate" type="text" title="{{ "mb.coordinatesutility.view.originCoordinates.title" | trans }} ({{ "mb.coordinatesutility.view.originCooridnates.tooltip" | trans }})" readonly="true" value=""/>
             <div class="icon iconBig copyClipBoard" title="{{ "mb.coordinatesutility.view.copytoclipboard.tooltip" | trans }}"></div>
         </div>
     </div>


### PR DESCRIPTION
* changed variable mb.coordinatesutility.view.originCoordinates.title to new syntax without typo
* changed variable mb.maptool.clickcoordinate.intern.coords.title (still used the old bundle translation) to mb.coordinatesutility.view.originCoordinates.title