### PR TITLE
fixed typo originCooridnates to originCoordinates

### DIFF
--- a/Resources/views/Element/coordinatesutility.html.twig
+++ b/Resources/views/Element/coordinatesutility.html.twig
@@ -19,7 +19,7 @@
     <div class="block coordinates-intern">
         <p>{{ "mb.coordinatesutility.view.originCoordinates.title" | trans }}</p>
         <div class="input-to-clipboard">
-            <input class="input map-coordinate" type="text" title="{{ "mb.coordinatesutility.view.originCoordinates.title" | trans }} ({{ "mb.coordinatesutility.view.originCooridnates.tooltip" | trans }})" readonly="true" value=""/>
+            <input class="input map-coordinate" type="text" title="{{ "mb.coordinatesutility.view.originCoordinates.title" | trans }} ({{ "mb.coordinatesutility.view.originCoordinates.tooltip" | trans }})" readonly="true" value=""/>
             <div class="icon iconBig copyClipBoard" title="{{ "mb.coordinatesutility.view.copytoclipboard.tooltip" | trans }}"></div>
         </div>
     </div>


### PR DESCRIPTION
one translation text had a typo originCooridnates. The typo was already fixed in the translation yml files