### PR TITLE
Remove dependency on friendsofsymfony/jsrouting-bundle

### DIFF
--- a/Resources/public/srs-autocomplete.js
+++ b/Resources/public/srs-autocomplete.js
@@ -14,7 +14,8 @@ $(".srs-autocomplete input")
     })
     .autocomplete({
         source: function (request, response) {
-            $.getJSON(Routing.generate('srs_autocomplete'), {
+            var url = $(this.element).data('autocomplete-url');
+            $.getJSON(url, {
                 term: extractLast(request.term)
             }, response);
         },

--- a/Resources/views/ElementAdmin/coordinatesutility.html.twig
+++ b/Resources/views/ElementAdmin/coordinatesutility.html.twig
@@ -11,7 +11,7 @@
 
     <div class="clearContainer"></div>
 
-    {{ form_label(form.configuration.srsList) }}{{ form_widget(form.configuration.srsList, { 'attr': {'class': 'srs-autocomplete'} }) }}
+    {{ form_label(form.configuration.srsList) }}{{ form_widget(form.configuration.srsList, { 'attr': {'class': 'srs-autocomplete', 'data-autocomplete-url': path('srs_autocomplete')}}) }}
     <div id="srs-autocomplete-variants"></div>
 
     <div class="clearContainer"></div>


### PR DESCRIPTION
Mapbender/CU does not correctly declare its dependency on friendsofsymfony/jsrouting-bundle and would break if the dependency were removed from Mapbender. 

Instead of declaring the dependency, this pull moves generation of autocomplete URL for CU Element backend form from JS to server, removing the functional dependency on FJR. The URL is generated in twig with the standard `path` twig method and attached to the input as a `data-autocomplete-url` attribute.

FJR dependency is currently rooted in Mapbender Starter, but only one remaining use has been identified im Mapbender (besides this one here in CU). FJR is a potential impediment to further Symfony upgrades and adds some complexity for build and delivery. We want to be able to drop FJR from Mapbender completely.

