### PR TITLE
inputCoordinates - replace , with . to avoid errors

### DIFF
--- a/Resources/public/mapbender.element.coordinatesutility.js
+++ b/Resources/public/mapbender.element.coordinatesutility.js
@@ -504,6 +504,7 @@
         _transformCoordinateToMapSrs: function () {
             var selectedSrs = $('select.srs', this.element).val();
             var inputCoordinates = $('input.input-coordinate', this.element).val();
+            inputCoordinates = inputCoordinates.replace(/,/g, '.');
             var inputCoordinatesArray = inputCoordinates.split(/ \s*/);
 
             var lat = parseFloat(inputCoordinatesArray.pop());


### PR DESCRIPTION
If someone defines coordinates with , this PR will replace , with .